### PR TITLE
Fix incorrect paths and command formatting in devdoc.vim and install.vim

### DIFF
--- a/autoload/devdocs/devdoc.vim
+++ b/autoload/devdocs/devdoc.vim
@@ -132,14 +132,14 @@ export def LoadPage(fpath: string, slug: string, absolute_path: bool = false)
         :echohl ErrorMsg | echoerr $'Failed to find pandoc' | echohl None
         return
     endif
-    var scriptdir = getscriptinfo({name: 'devdocs'})[0].name->fnamemodify(':h:h')
+    var scriptdir = getscriptinfo({name: 'devdoc.vim'})[0].name->fnamemodify(':h:h:h')
     var opts = GetOptionStr()
     const TEXT_INDENT = 4
     var right_margin = 2 * TEXT_INDENT
     var docwidth = min([300, max([winwidth(0) - right_margin, 50])])
 
     task.AsyncCmd.new(
-        $'{options.opt.pandoc} --columns={docwidth} -t {scriptdir}/pandoc/writer.lua {fullpath}',
+        $'{options.opt.pandoc} --columns={docwidth} -t "{scriptdir}/pandoc/writer.lua" "{fullpath}"',
         (msg: string) => {
             var doc: dict<any>
             try

--- a/autoload/devdocs/install.vim
+++ b/autoload/devdocs/install.vim
@@ -40,7 +40,11 @@ def Extract(outdir: string): bool
         :echohl ErrorMsg | echoerr $'Failed to remove {outdir}' | echohl None
         return false
     endif
-    $'mv {tmpdir} {outdir}'->system()
+	if has('win32') || has('win64')
+		$'ren "{tmpdir}" "{outdir}"'->system()
+	else
+		$'mv "{tmpdir}" "{outdir}"'->system()
+	endif
     if v:shell_error != 0
         :echohl ErrorMsg | echoerr $'Failed to rename {outdir}' | echohl None
         return false

--- a/autoload/devdocs/install.vim
+++ b/autoload/devdocs/install.vim
@@ -40,11 +40,11 @@ def Extract(outdir: string): bool
         :echohl ErrorMsg | echoerr $'Failed to remove {outdir}' | echohl None
         return false
     endif
-	if has('win32') || has('win64')
-		$'ren "{tmpdir}" "{outdir}"'->system()
-	else
-		$'mv "{tmpdir}" "{outdir}"'->system()
-	endif
+    if (has('win32') != 0) || (has('win64') != 0)
+        $'move "{tmpdir}" "{outdir}"'->system()
+    else
+        $'mv "{tmpdir}" "{outdir}"'->system()
+    endif
     if v:shell_error != 0
         :echohl ErrorMsg | echoerr $'Failed to rename {outdir}' | echohl None
         return false


### PR DESCRIPTION
- Corrected the scriptdir path in devdoc.vim to point to the right location
- Updated the command formatting in devdoc.vim to properly encapsulate paths
- Modified the file renaming command in install.vim to be compatible with Windows platforms

closes :

- https://github.com/girishji/devdocs.vim/issues/9 
- https://github.com/girishji/devdocs.vim/issues/8